### PR TITLE
Intialisation and Adding errors quickstart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
-*.class
-
-# Package Files #
-*.jar
-*.war
-*.ear
+target
+.idea
+*.iml
+*.im
+*.ipr
+*.iws
+overlays
+.DS_Store
+.settings
+*.swp
+*.log
+.project
+.classpath

--- a/errors/README.md
+++ b/errors/README.md
@@ -1,0 +1,88 @@
+errors: demonstrates exception handling in Camel
+===================================
+Author: Fuse Team
+Level: Beginner
+Technologies: Fuse, OSGi, Camel
+Summary: Demonstrates Exception handling in Camel
+Target Product: Fuse
+Source: <https://github.com/jboss-fuse/quickstarts/errors>
+
+What is it?
+-----------
+
+This quickstart demonstrates how to handle exceptions that occur while routing messages with Camel.
+
+This quickstart show you how to add a default error handler to your Camel context for all uncaught exceptions.
+ Additionally, it will show you how to add exception handling routines for dealing with specific exception types.
+
+In studying this example you will learn:
+
+* how to define a Camel route using the Blueprint XML syntax
+* how to build and deploy a Fuse Application Bundle (FAB) in JBoss Fuse
+* how to define a default error handler to your Camel context
+* how to define exception-specific error handling routines
+
+For more information see:
+
+* http://www.enterpriseintegrationpatterns.com/DeadLetterChannel.html for the Dead Letter Channel EIP
+* https://access.redhat.com/knowledge/docs/JBoss_Fuse/ for more information about using JBoss Fuse
+
+
+System requirements
+-------------------
+
+Before building and running this example you need:
+
+* Maven 3.0.3 or higher
+* JDK 1.6 or 1.7
+* JBoss Fuse 6
+
+
+Build and Deploy the Quickstart
+-------------------------
+
+1. Change your working directory to `quckstarts/errors` directory.
+2. Run `mvn clean install` to build the quickstart.
+3. Start JBoss Fuse 6 by running bin/fuse (on Linux) or bin\fuse.bat (on Windows).
+4. In the JBoss Fuse console, enter the following command:
+
+        osgi:install -s fab:mvn:org.jboss.quickstarts.fuse/errors/<project version>
+
+5. Fuse should give you on id when the bundle is deployed
+6. You can check that everything is ok by issue the command:
+
+        osgi:list
+   your bundle should be at the end of the list
+
+
+Use the application
+-------------------
+
+To use the application be sure to have deployed the quickstart in Fuse as described above. Successful deployment will create and start a Camel route in Fuse.
+
+1. As soon as the Camel route has been started, you will see a directory `work/errors/input` in your JBoss Fuse installation.
+2. Copy the file you find in this example's `src/test/data` directory to the newly created `work/errors/input` directory.
+4. Wait a few moment and you will find the files in directories under `work/errors`:
+
+  * `order4.xml` will always end up in the `work/errors/validation` directory
+  * other files will end up in `work/errors/done` or `work/errors/deadletter` depending on the runtime exceptions that occur
+5. Use `log:display` to check out the business logging - the exact output may look differently because the 'unexpected runtime exception...' happen randomly
+
+        Processing order4.xml
+        Order validation failure: order date 2012-03-04 should not be a Sunday
+        Validation failed for order4.xml - moving the file to work/errors/validation
+        Processing order5.xml
+        An unexcepted runtime exception occurred while processing order5.xml
+        Done processing order5.xml
+        ...
+
+Undeploy the Bundle
+--------------------
+
+To stop and undeploy the bundle in Fuse:
+
+1. Enter `osgi:list` command to retrieve your bundle id
+2. To stop and uninstall the bundle enter
+
+        osgi:uninstall <id>
+ 

--- a/errors/pom.xml
+++ b/errors/pom.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0"?>
+<!--
+  JBoss, Home of Professional Open Source
+   Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+   contributors by the @authors tag. See the copyright.txt in the
+   distribution for a full listing of individual contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.quickstarts.fuse</groupId>
+    <artifactId>errors</artifactId>
+    <version>99-master-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>JBoss Fuse :: Examples :: Error Handling</name>
+    <description>Handle errors in the Camel m</description>
+
+    <properties>
+        <!-- Explicitly declaring the source encoding eliminates the following
+                   message: -->
+        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
+            resources, i.e. build is platform dependent! -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+
+        <version.camel-blueprint>2.10.0.redhat-60024</version.camel-blueprint>
+        <version.slf4j>1.6.1</version.slf4j>
+        <version.junit>4.10</version.junit>
+
+        <version.compiler.plugin>2.3.1</version.compiler.plugin>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <!--
+          For this example, we will be using the OSGi Blueprint XML syntax for Apache Camel.
+          The camel-blueprint bundle is installed in JBoss Fuse by default,
+          so we are setting the dependency's scope to 'provided'.
+        -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-blueprint</artifactId>
+            <version>${version.camel-blueprint}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!--
+          For logging, we will use SLF4J, which is also available in the container by default.
+        -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${version.slf4j}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!--
+          Dependencies with scope 'test' will be ignored when installing this Fuse Application Bundle (FAB) in the container
+          but they will be available in our test classes.q
+        -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${version.junit}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--
+          Add the slf4j-log4j12 dependency jar for testing
+        -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${version.slf4j}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>fusesource.m2</id>
+            <name>FuseSource Community Release Repository</name>
+            <url>http://repo.fusesource.com/nexus/content/repositories/releases</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+        <repository>
+            <id>fusesource.ea</id>
+            <name>FuseSource Community Early Access Release Repository</name>
+            <url>http://repo.fusesource.com/nexus/content/groups/ea</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>fusesource.m2</id>
+            <name>FuseSource Community Release Repository</name>
+            <url>http://repo.fusesource.com/nexus/content/repositories/releases</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </pluginRepository>
+        <pluginRepository>
+            <id>fusesource.ea</id>
+            <name>FuseSource Community Early Access Release Repository</name>
+            <url>http://repo.fusesource.com/nexus/content/groups/ea</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <build>
+
+        <plugins>
+            <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${version.compiler.plugin}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/errors/src/main/java/org/jboss/quickstarts/fuse/errors/OrderService.java
+++ b/errors/src/main/java/org/jboss/quickstarts/fuse/errors/OrderService.java
@@ -1,0 +1,85 @@
+/**
+ * JBoss, Home of Professional Open Source
+ *  Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ *  contributors by the @authors tag. See the copyright.txt in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jboss.quickstarts.fuse.errors;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Header;
+import org.apache.camel.language.NamespacePrefix;
+import org.apache.camel.language.XPath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Random;
+
+/**
+ * An order service implementation that provides one method to do validation and another method that just randomly throws
+ * Exceptions to be able to test error handling in our Camel route.
+ */
+public class OrderService {
+
+    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+    private static final Logger LOGGER = LoggerFactory.getLogger(OrderService.class);
+    private static final Random RANDOM = new Random();
+
+    /**
+     * Validate the order date - orders should only be place from Monday to Saturday.
+     * <p/>
+     * This method can be used as a plain Java method, but when it is used inside a Camel route, the @XPath annotation will kick
+     * in, evaluating the XPath expression and using the result as the method parameter. In this case, it will fetch the order
+     * date from the order XML message.
+     *
+     * @param date the order date
+     * @throws OrderValidationException when the order date is a Sunday
+     */
+    public void validateOrderDate(
+            @XPath(value = "/order:order/order:date",
+                    namespaces = @NamespacePrefix(prefix = "order", uri = "http://fusesource.com/examples/order/v7")) String
+                    date
+    ) throws OrderValidationException {
+        final Calendar calendar = new GregorianCalendar();
+        try {
+            calendar.setTime(DATE_FORMAT.parse(date));
+            if (calendar.get(Calendar.DAY_OF_WEEK) == Calendar.SUNDAY) {
+                LOGGER.warn("Order validation failure: order date " + date + " should not be a Sunday");
+                throw new OrderValidationException("Order date should not be a Sunday: " + date);
+            }
+        } catch (ParseException e) {
+            throw new OrderValidationException("Invalid order date: " + date);
+        }
+    }
+
+    /**
+     * This method throws a runtime exception 2 out of 3 times. This is completely useless in real life, but in this example we
+     * use this to demonstrate Camel's error handling capabilities.
+     * <p/>
+     * In order to be able to log which file is being processed when throwing the exception, we the Camel @Header annotation to
+     * extract the file name from the message.
+     *
+     * @param name the file name
+     */
+    public void randomlyThrowRuntimeException(@Header(Exchange.FILE_NAME) String name) {
+        if (RANDOM.nextInt(3) > 0) {
+            LOGGER.warn("An unexcepted runtime exception occurred while processing " + name);
+            throw new RuntimeException("Something else went wrong while handling this message");
+        }
+    }
+}

--- a/errors/src/main/java/org/jboss/quickstarts/fuse/errors/OrderValidationException.java
+++ b/errors/src/main/java/org/jboss/quickstarts/fuse/errors/OrderValidationException.java
@@ -1,0 +1,27 @@
+/**
+ * JBoss, Home of Professional Open Source
+ *  Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ *  contributors by the @authors tag. See the copyright.txt in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jboss.quickstarts.fuse.errors;
+
+/**
+ * Exception raised when order validation fails.
+ */
+public class OrderValidationException extends Exception {
+
+    public OrderValidationException(String text) {
+        super("Order validation failed: " + text);
+    }
+}

--- a/errors/src/main/resources/OSGI-INF/blueprint/errors.xml
+++ b/errors/src/main/resources/OSGI-INF/blueprint/errors.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  JBoss, Home of Professional Open Source
+   Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+   contributors by the @authors tag. See the copyright.txt in the
+   distribution for a full listing of individual contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+<!--
+   This is the OSGi Blueprint XML file defining the Camel context and routes.  Because the file is in the
+   OSGI-INF/blueprint directory inside our JAR, it will be automatically activated as soon as the artifact is being installed.
+
+   The root element for any OSGi Blueprint file is 'blueprint' - you also see the namespace definitions for both the Blueprint
+   and the Camel namespaces.
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="
+             http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+             http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+
+
+    <!--
+      We are using the OSGi Blueprint XML syntax to define a bean that we use in our Camel route to validate
+      the order date. It has a method that intermittently throws runtime exceptions.
+    -->
+    <bean id="myOrderService" class="org.jboss.quickstarts.fuse.errors.OrderService"/>
+
+    <!--
+      Here, we define the dead-letter channel configuration we want to use.  We want to retry delivering a failed exchange
+      twice and we also want to use exponential backoff between retries (so first retry after 1 second, second retry another
+      2 seconds later).  After a total of 3 failed deliveries (1 initial delivery plus our 2 redeliveries), the message will
+      be sent to the configured dead letter uri (direct:deadletter).
+    -->
+    <bean id="myDeadLetterErrorHandler" class="org.apache.camel.builder.DeadLetterChannelBuilder">
+        <property name="deadLetterUri" value="direct:deadletter"/>
+        <property name="redeliveryPolicy">
+            <bean class="org.apache.camel.processor.RedeliveryPolicy">
+                <property name="maximumRedeliveries" value="2"/>
+                <property name="useExponentialBackOff" value="true"/>
+            </bean>
+        </property>
+    </bean>
+
+    <!--
+      The namespace for the camelContext element in Blueprint is 'http://camel.apache.org/schema/blueprint'.  Additionally,
+      we can also define namespace prefixes we want to use in the XPath expressions in our CBR here.
+
+      While it is not required to assign id's to the <camelContext/> and <route/> elements, it is usually a good idea
+      to set those for runtime management purposes (logging, JMX MBeans, ...)
+
+      We also configure the default error handler for this Camel context by setting the errorHandlerRef attribute to the
+      'myDeadLetterErrorHandler' bean defined earlier.  Any exceptions that are not being handled by a more specific
+      mechanism (e.g. an <onException/> or <doTry/>) will be handled by this default error handler.
+    -->
+    <camelContext xmlns="http://camel.apache.org/schema/blueprint"
+                  id="errors-example-context"
+                  errorHandlerRef="myDeadLetterErrorHandler">
+
+        <!--
+          Using <onException/>, we can define recovery scenarios for specific exceptions.  In our case, if order date validation
+          fails (OrderValidationException is thrown, we want to move the file to the work/errors/validation folder.
+
+          We don't specify a redelivery policy and mark the exception handled to ensure processing will not be retried for this exception.
+        -->
+        <onException>
+            <exception>org.jboss.quickstarts.fuse.errors.OrderValidationException</exception>
+            <handled>
+                <constant>true</constant>
+            </handled>
+            <log message="Validation failed for ${file:name} - moving the file to work/errors/validation"/>
+            <to uri="file:work/errors/validation"/>
+        </onException>
+
+        <!--
+          This is the main Camel route.  Files dropped in work/errors/input directory will be processed by two methods in our order service bean:
+          - the first method will validate the order date - it will throw an OrderValidationException whenever the order date is a Sunday
+            these exceptions will be handled by the <onException/> definition
+          - the second method will just randomly throw a RuntimeException 2 out of 3 times
+            our default error handler strategy configured on the <camelContext/> will retry the exchange 3 times and afterwards send it to the dead letter channel
+        -->
+        <route id="mainRoute">
+            <from uri="file:work/errors/input"/>
+            <log message="Processing ${file:name}"/>
+            <to uri="bean:myOrderService?method=validateOrderDate"/>
+            <to uri="bean:myOrderService?method=randomlyThrowRuntimeException"/>
+            <to uri="file:work/errors/done"/>
+            <log message="Done processing ${file:name}"/>
+        </route>
+
+        <!--
+          This route starts with the direct:deadletter endpoint we used in the 'myDeadLetterErrorHandler' bean definition,
+          so any exchanges that have failed delivery 3 times will be sent to this route.  The route itself logs a human-friendly
+          error message and afterwards stores the failed message in the work/errors/deadletter folder.
+        -->
+        <route id="dlcRoute">
+            <from uri="direct:deadletter"/>
+            <log message="File ${file:name} was moved to the dead letter channel"/>
+            <to uri="file:work/errors/deadletter"/>
+        </route>
+
+    </camelContext>
+
+</blueprint>

--- a/errors/src/main/resources/data/order1.xml
+++ b/errors/src/main/resources/data/order1.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  JBoss, Home of Professional Open Source
+   Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+   contributors by the @authors tag. See the copyright.txt in the
+   distribution for a full listing of individual contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+
+<order xmlns="http://fusesource.com/examples/order/v7">
+
+    <customer id="A0001">
+        <name>Antwerp Zoo</name>
+        <city>Antwerp</city>
+        <country>BE</country>
+    </customer>
+
+    <date>2012-03-01</date>
+
+    <orderlines>
+        <orderline>
+            <article id="A0001">
+                <description>Aardvark</description>
+            </article>
+            <quantity>1</quantity>
+        </orderline>
+        <orderline>
+            <article id="A0011">
+                <description>Alpaca</description>
+            </article>
+            <quantity>10</quantity>
+        </orderline>
+    </orderlines>
+
+</order>

--- a/errors/src/main/resources/data/order2.xml
+++ b/errors/src/main/resources/data/order2.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  JBoss, Home of Professional Open Source
+   Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+   contributors by the @authors tag. See the copyright.txt in the
+   distribution for a full listing of individual contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+
+<order xmlns="http://fusesource.com/examples/order/v7">
+
+    <customer id="B0002">
+        <name>Bristol Zoo Gardens</name>
+        <city>Bristol</city>
+        <country>UK</country>
+    </customer>
+
+    <date>2012-03-02</date>
+
+    <orderlines>
+        <orderline>
+            <article id="B0002">
+                <description>Badger</description>
+            </article>
+            <quantity>2</quantity>
+        </orderline>
+        <orderline>
+            <article id="B0202">
+                <description>Bee</description>
+            </article>
+            <quantity>200</quantity>
+        </orderline>
+    </orderlines>
+</order>

--- a/errors/src/main/resources/data/order3.xml
+++ b/errors/src/main/resources/data/order3.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  JBoss, Home of Professional Open Source
+   Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+   contributors by the @authors tag. See the copyright.txt in the
+   distribution for a full listing of individual contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+
+<order xmlns="http://fusesource.com/examples/order/v7">
+
+    <customer id="C0003">
+        <name>Columbus Zoo and Aquarium</name>
+        <city>Columbus</city>
+        <country>US</country>
+    </customer>
+
+    <date>2012-03-03</date>
+
+    <orderlines>
+        <orderline>
+            <article id="C0003">
+                <description>Camel</description>
+            </article>
+            <!-- we all love Camels, don't we ;) ? -->
+            <quantity>100</quantity>
+        </orderline>
+        <orderline>
+            <article id="C0333">
+                <description>Crocodile</description>
+            </article>
+            <quantity>1</quantity>
+        </orderline>
+    </orderlines>
+</order>

--- a/errors/src/main/resources/data/order4.xml
+++ b/errors/src/main/resources/data/order4.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  JBoss, Home of Professional Open Source
+   Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+   contributors by the @authors tag. See the copyright.txt in the
+   distribution for a full listing of individual contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+
+<order xmlns="http://fusesource.com/examples/order/v7">
+
+    <customer id="D0004">
+        <name>Dartmoor Zoological Park</name>
+        <city>Devon</city>
+        <country>UK</country>
+    </customer>
+
+    <date>2012-03-04</date>
+
+    <orderlines>
+        <orderline>
+            <article id="D0040">
+                <description>Dinosaur</description>
+            </article>
+            <quantity>4</quantity>
+        </orderline>
+        <orderline>
+            <article id="D0400">
+                <description>Dragonfly</description>
+            </article>
+            <quantity>40</quantity>
+        </orderline>
+    </orderlines>
+</order>

--- a/errors/src/main/resources/data/order5.xml
+++ b/errors/src/main/resources/data/order5.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  JBoss, Home of Professional Open Source
+   Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+   contributors by the @authors tag. See the copyright.txt in the
+   distribution for a full listing of individual contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+
+<order xmlns="http://fusesource.com/examples/order/v7">
+
+    <customer id="E0004">
+        <name>Erie Zoo</name>
+        <city>Erie</city>
+        <country>US</country>
+    </customer>
+
+    <date>2012-03-05</date>
+
+    <orderlines>
+        <orderline>
+            <article id="E0500">
+                <description>Elk</description>
+            </article>
+            <quantity>50</quantity>
+        </orderline>
+        <orderline>
+            <article id="E0005">
+                <description>Elephant</description>
+            </article>
+            <quantity>5</quantity>
+        </orderline>
+    </orderlines>
+</order>

--- a/errors/src/test/java/org/jboss/quickstarts/fuse/errors/OrderServiceTest.java
+++ b/errors/src/test/java/org/jboss/quickstarts/fuse/errors/OrderServiceTest.java
@@ -1,0 +1,46 @@
+/**
+ * JBoss, Home of Professional Open Source
+ *  Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ *  contributors by the @authors tag. See the copyright.txt in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jboss.quickstarts.fuse.errors;
+
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Just a simple JUnit test class for {@link OrderService}
+ */
+public class OrderServiceTest {
+
+    private OrderService service = new OrderService();
+
+    @Test
+    public void testValidateValidOrderDate() {
+        try {
+            service.validateOrderDate("2012-03-01");
+            service.validateOrderDate("2012-03-02");
+            service.validateOrderDate("2012-03-03");
+            service.validateOrderDate("2012-03-05");
+        } catch (OrderValidationException e) {
+            fail("No OrderValidationException expected - we can accept orders on any of those dates");
+        }
+    }
+
+    @Test(expected = OrderValidationException.class)
+    public void testValidateInvalidOrderDate() throws OrderValidationException {
+        service.validateOrderDate("2012-03-04");
+    }
+}

--- a/errors/src/test/resources/log4j.properties
+++ b/errors/src/test/resources/log4j.properties
@@ -1,0 +1,35 @@
+#
+# JBoss, Home of Professional Open Source
+#  Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+#  contributors by the @authors tag. See the copyright.txt in the
+#  distribution for a full listing of individual contributors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+log4j.rootLogger=INFO, file
+
+# CONSOLE appender not used by default
+log4j.appender.out=org.apache.log4j.ConsoleAppender
+log4j.appender.out.layout=org.apache.log4j.PatternLayout
+log4j.appender.out.layout.ConversionPattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
+# MDC
+#log4j.appender.out.layout.ConversionPattern=%d [%-15.15t] %-5p %-30.30c{1} - %-10.10X{camel.breadcrumbId} - %-10.10X{camelexchangeId} - %-10.10X{camel.correlationId} - %-10.10X{camel.routeId} - %m%n
+
+# File appender
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.file=target/errors.log
+log4j.appender.file.append=true
+log4j.appender.file.layout.ConversionPattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
+# MDC
+#log4j.appender.file.layout.ConversionPattern=%d [%-15.15t] %-5p %-30.30c{1} - %-10.10X{camel.breadcrumbId} - %-10.10X{camel.exchangeId} - %-10.10X{camel.correlationId} - %-10.10X{camel.routeId} - %m%n
+
+log4j.throwableRenderer=org.apache.log4j.EnhancedThrowableRenderer

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.jboss.quickstarts.fuse</groupId>
+    <artifactId>jboss-quickstarts-fuse-parent</artifactId>
+    <version>6.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>JBoss Fuse Quickstarts Parent</name>
+    <description>JBoss Fuse Quickstarts Parent</description>
+    <url>http://www.jboss.org/products/fuse</url>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+
+    <modules>
+        <module>errors</module>
+    </modules>
+
+
+</project>

--- a/template/README.md
+++ b/template/README.md
@@ -1,0 +1,249 @@
+QUICKSTART_NAME: Brief Description of the Quickstart
+======================================================
+Author: YOUR_NAME and optional CONTACT_INFO
+Level: [one of the following: Beginner, Intermediate, or Advanced]
+Technologies: (list technologies used here)
+Summary: (a brief description of the quickstart to appear in the table )
+Prerequisites: (list any quickstarts that must be deployed prior to running this one)
+Target Product: (EAP, WFK, JDG, etc)
+Source: (The URL for the repository that is the source of record for this quickstart)
+
+
+_This file is meant to serve as a template or guideline for your own quickstart README.md file. Be sure to replace QUICKSTART_NAME and YOUR_NAME, with the appropriate values._
+
+Contributor instructions are prefixed with 'Contributor: '
+
+What is it?
+-----------
+
+Contributor: This is where you provide an overview of what the quickstart demonstrates. For example:
+
+ * What are the technologies demonstrated by the quickstart?
+ * What does it do when you run it?
+
+You should include any information that would help the user understand the quickstart.  
+
+If possible, give an overview, including any code they should look at to understand how it works..
+
+
+System requirements
+-------------------
+
+Contributor: For example: 
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
+
+The application this project produces is designed to be run on JBoss Enterprise Application Platform 6 or JBoss AS 7. 
+
+ 
+Configure Maven
+---------------
+
+Contributor: You can copy or link to the Maven configuration information in the README file in the root folder of the quickstarts. For example:
+
+If you have not yet done so, you must [Configure Maven](../README.md#configure-maven) before testing the quickstarts.
+
+
+Configure Optional Components
+-------------------------
+
+Contributor: If your quickstart requires any additional components, decribe how to set them up here. If your quickstart requires a secured user, PostgreSQL, or Byteman, you can link to the instructions in the README file located in the root folder of the quickstart directory. Here are some examples:
+
+ * This quickstart uses a secured management interface and requires that you create a management (or application) user to access the running application. Instructions to set up a Management (or Application) user can be found here: 
+
+    * [Add a Management User](../README.md#add-a-management-user)
+
+    * [Add an Application User](../README.md#add-an-application-user)
+
+ * This quickstart requires the PostgreSQL database. Instructions to install an configure PostgreSQL can be found here: [Install and Configure the PostgreSQL Database](../README.md#install-and-configure-the-postgresql-database)
+
+ * This quickstart uses Byteman to help demonstrate crash recovery. Instructions to install and configure Byteman can be found here: [Install and Configure Byteman](../README.md#install-and-configure-byteman)
+
+
+Start JBoss Enterprise Application Platform 6 or JBoss AS 7
+-------------------------
+
+Contributor: Does this quickstart require one or more running servers? If so, you must show how to start the server. If you start the server in one of the following 3 ways, you can simply copy the instructions in the README file located in the root folder of the quickstart directory:
+
+ * Start JBoss Enterprise Application Platform 6 or JBoss AS 7 with the Web Profile
+
+ * Start JBoss Enterprise Application Platform 6 or JBoss AS 7 with the Full Profile
+
+ * Start JBoss Enterprise Application Platform 6 or JBoss AS 7 with Custom Options. You will need to provide the argument string to pass on the command line, for example: 
+
+      `--server-config=../../docs/examples/configs/standalone-xts.xml`
+
+Contributor: If the server is started in a different manner than above, give the specific instructions.
+
+
+Build and Deploy the Quickstart
+-------------------------
+
+Contributor: If the quickstart is built and deployed using the standard Maven commands, "mvn clean package" and "mvn jboss-as:deploy", copy the following:
+
+_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See [Build and Deploy the Quickstarts](../README.md#build-and-deploy-the-quickstarts) for complete instructions and additional options._
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. Type this command to build and deploy the archive:
+
+        mvn clean package jboss-as:deploy
+4. This will deploy `target/jboss-as-QUICKSTART_NAME.war` (or `target/jboss-as-QUICKSTART_NAME.ear`) to the running instance of the server.
+ 
+Contributor: Be sure to replace the QUICKSTART_NAME. If this quickstart requires different or additional instructions, be sure to modify or add those instructions here.
+
+
+Access the application (For quickstarts that have a UI component)
+---------------------
+
+Contributor: Provide the URL to access the running application. Be sure to make the URL a hyperlink as below, substituting the your quickstart name for the QUICKSTART_NAME. 
+
+        Access the running application in a browser at the following URL:  <http://localhost:8080/jboss-as-QUICKSTART_NAME>
+
+
+Contributor: Briefly describe what you will see when you access the application. For example: 
+
+        You will be presented with a simple form for adding key/value pairs and a checkbox to indicate whether the updates should be executed using an unmanaged component. 
+
+            If the box is checked, the updates will be executed within a session bean method. 
+            If the box is not checked, the transactions and JPA updates will run in a servlet instead of session beans. 
+
+        To list all existing key/value pairs, leave the key input box empty. 
+    
+        To add or update the value of a key, enter a key and value input boxe and click the submit button to see the results.
+
+Contributor: Add any information that will help them run and understand your quickstart.
+
+
+Undeploy the Archive
+--------------------
+
+Contributor: For example: 
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. When you are finished testing, type this command to undeploy the archive:
+
+        mvn jboss-as:undeploy
+
+
+Run the Arquillian Tests (For quickstarts that contain Arquillian tests)
+-------------------------
+
+Contributor: For example: 
+
+This quickstart provides Arquillian tests. By default, these tests are configured to be skipped as Arquillian tests require the use of a container. 
+
+_NOTE: The following commands assume you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See [Run the Arquillian Tests](../README.md#run-the-arquillian-tests) for complete instructions and additional options._
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. Type the following command to run the test goal with the following profile activated:
+
+        mvn clean test -Parq-jbossas-remote 
+
+Contributor: The quickstart README should show what to expect from the the tests
+
+* Copy and paste output from the JUnit tests to show what to expect in the console from the tests.
+
+* Copy and paste log messages output by the application to show what to expect in the server log when running the tests.
+
+
+
+Run the Quickstart in JBoss Developer Studio or Eclipse
+-------------------------------------
+Contributor: For example: 
+
+You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see [Use JBoss Developer Studio or Eclipse to Run the Quickstarts](../README.md#use-jboss-developer-studio-or-eclipse-to-run-the-quickstarts) 
+
+Debug the Application
+------------------------------------
+
+Contributor: For example: 
+
+If you want to debug the source code or look at the Javadocs of any library in the project, run either of the following commands to pull them into your local repository. The IDE should then detect them.
+
+    mvn dependency:sources
+    mvn dependency:resolve -Dclassifier=javadoc
+
+
+
+Build and Deploy the Quickstart - to OpenShift
+-------------------------
+
+Contributor: If the quickstart deploys to OpenShift, you can use the following template a starting point to describe the process. Be sure to note:
+
+* APPLICATION_NAME should be replaced with a variation of the quickstart name, for example: myquickstart
+* QUICKSTART_NAME should be replaced with your quickstart name, for example:  my-quickstart
+
+### Create an OpenShift Account and Domain
+
+If you do not yet have an OpenShift account and domain, [Sign in to OpenShift](https://openshift.redhat.com/app/login) to create the account and domain. [Get Started with OpenShift](https://openshift.redhat.com/app/getting_started) will show you how to install the OpenShift Express command line interface.
+
+### Create the OpenShift Application
+
+Open a shell command prompt and change to a directory of your choice. Enter the following command, replacing APPLICATION_TYPE with `jbosseap-6.0` for quickstarts running on JBoss Enterprise Application Platform 6, or `jbossas-7` for quickstarts running on JBoss AS 7:
+
+    rhc app create -a APPLICATION_NAME -t APPLICATION_TYPE
+
+_NOTE_: The domain name for this application will be APPLICATION_NAME-YOUR_DOMAIN_NAME.rhcloud.com`. Here we use the _quickstart_ domain. You will need to replace it with your own OpenShift domain name.
+
+This command creates an OpenShift application named  and will run the application inside the `jbosseap-6.0`  or `jbossas-7` container. You should see some output similar to the following:
+
+    Creating application: APPLICATION_NAME
+    Now your new domain name is being propagated worldwide (this might take a minute)...
+    Warning: Permanently added 'APPLICATION_NAME-quickstart.rhcloud.com,107.22.36.32' (RSA) to the list of known hosts.
+    Confirming application 'APPLICATION_NAME' is available:  Success!
+    
+    APPLICATION_NAME published:  http://APPLICATION_NAME-quickstart.rhcloud.com/
+    git url:  ssh://b92047bdc05e46c980cc3501c3577c1e@APPLICATION_NAME-quickstart.rhcloud.com/~/git/APPLICATION_NAME.git/
+    Successfully created application: APPLICATION_NAME
+
+The create command creates a git repository in the current directory with the same name as the application. Notice that the output also reports the URL at which the application can be accessed. Make sure it is available by typing the published url <http://APPLICATION_NAME-quickstart.rhcloud.com/> into a browser or use command line tools such as curl or wget.
+
+### Migrate the Quickstart Source
+
+Now that you have confirmed it is working you can migrate the quickstart source. You do not need the generated default application, so navigate to the new git repository directory and tell git to remove the source and pom files:
+
+    cd APPLICATION_NAME
+    git rm -r src pom.xml
+
+Copy the source for the QUICKSTART_NAME quickstart into this new git repository:
+
+    cp -r QUICKSTART_HOME/QUICKSTART_NAME/src .
+    cp QUICKSTART_HOME/QUICKSTART_NAME/pom.xml .
+
+### Configure the OpenShift Server
+
+Contributor: Here you describe any modifications needed for the `.openshift/config/standalone.xml` file. See other quickstart README.md files for examples.
+
+### Deploy the OpenShift Application
+
+You can now deploy the changes to your OpenShift application using git as follows:
+
+    git add src pom.xml
+    git commit -m "QUICKSTART_NAME quickstart on OpenShift"
+    git push
+
+The final push command triggers the OpenShift infrastructure to build and deploy the changes. 
+
+Note that the `openshift` profile in `pom.xml` is activated by OpenShift, and causes the war build by openshift to be copied to the `deployments` directory, and deployed without a context path.
+
+### Test the OpenShift Application
+
+When the push command returns you can test the application by getting the following URL either via a browser or using tools such as curl or wget:
+
+* <http://APPLICATION_NAME-quickstart.rhcloud.com/> 
+
+You can use the OpenShift command line tools or the OpenShift web console to discover and control the application.
+
+### Destroy the OpenShift Application
+
+When you are finished with the application you can destroy it as follows:
+
+        rhc app destroy -a APPLICATION_NAME
+
+_Note_: There is a limit to the number of applications you can deploy concurrently to OpenShift. If the `rhc app create` command returns an error indicating you have reached that limit, you must destroy an existing application before you continue. 
+
+* To view the list of your OpenShift applications, type: `rhc domain show`
+* To destroy an existing application, type the following, substituting the application name you want to destroy: `rhc app destroy -a APPLICATION_NAME_TO_DESTROY`


### PR DESCRIPTION
After discussion in https://github.com/jboss-fuse/fuse/pull/36 it was decided to start a fresh repo for Fuse quickstarts. So this repository will contain JDF compliant version of Fuse Example. 

This PR proposes the "errors" quickstart in compliance with JDF guidelines and convention found in https://github.com/jboss-jdf/jboss-as-quickstart/blob/master/CONTRIBUTING.md#general-guidelines (Except for the BOM part that'll come in a second time).
For "errors" example it is mainly:
- renaming packages to org.jboss.quickstarts.fuse.errors
- reformatting code to follow JBoss code style
- moving example data to src/main/resources folder
- put the right licence in each file and in pom.xml
- modify documentation to use the sections than in https://github.com/jboss-jdf/jboss-as-quickstart/blob/master/template/README.md 
- optimizing pom to meet all JDF guidelines (except BOM requirement)
- running JDF qstools (https://github.com/jboss-jdf/qstools) to validate compliance

This PR also adds documentation template from https://github.com/jboss-jdf/jboss-as-quickstart
