### PR TITLE
Added remote repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,5 +46,10 @@
         <module>secure-soap</module>
     </modules>
 
-
+    <repositories>
+        <repository>
+            <id>FuseRepository</id>
+            <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
Hi,

One of the most annoying things with Maven based samples is finding out which Maven repository needs to be added before all dependencies can be resolved. A quick solution for this is to add a repository in the root project's pom.xml itself. 

It allows for building it ootb, instead of having to search which repository you need to add. Plus, if you already have it it doesn't hurt either, so no pain - much gain.

Cheers,
Roel
