### PR TITLE
Corrected Customer Portal Documentation Link in README files

### DIFF
--- a/cbr/README.md
+++ b/cbr/README.md
@@ -25,7 +25,7 @@ In studying this quick start you will learn:
 For more information see:
 
 * http://www.enterpriseintegrationpatterns.com/ContentBasedRouter.html for more information about the CBR EIP
-* https://access.redhat.com/site/documentation/JBoss_Fuse/ for more information about using JBoss Fuse
+* https://access.redhat.com/site/documentation/red-hat-jboss-fuse/ for more information about using JBoss Fuse
 
 Note: Extra steps, like use of Camel VM Component, need to be taken when accessing Camel Routes in different Camel Contexts, and in different OSGi bundles, as you are dealing with classes in different ClassLoaders.
 

--- a/eip/README.md
+++ b/eip/README.md
@@ -41,7 +41,7 @@ For more information see:
 * http://www.enterpriseintegrationpatterns.com/WireTap.html
 * http://www.enterpriseintegrationpatterns.com/Filter.html
 * http://www.enterpriseintegrationpatterns.com/Sequencer.html
-* https://access.redhat.com/site/documentation/JBoss_Fuse/
+* https://access.redhat.com/site/documentation/red-hat-jboss-fuse/
 
 
 System requirements

--- a/errors/README.md
+++ b/errors/README.md
@@ -25,7 +25,7 @@ In studying this quick start you will learn:
 For more information see:
 
 * http://www.enterpriseintegrationpatterns.com/DeadLetterChannel.html for the Dead Letter Channel EIP
-* https://access.redhat.com/site/documentation/JBoss_Fuse/ for more information about using JBoss Fuse
+* https://access.redhat.com/site/documentation/red-hat-jboss-fuse/ for more information about using JBoss Fuse
 
 
 System requirements

--- a/jms/README.md
+++ b/jms/README.md
@@ -25,7 +25,7 @@ In studying this quick start you will learn:
 For more information see:
 
 * http://www.enterpriseintegrationpatterns.com/ContentBasedRouter.html for more information about the CBR EIP
-* https://access.redhat.com/site/documentation/JBoss_Fuse/ for more information about using JBoss Fuse
+* https://access.redhat.com/site/documentation/red-hat-jboss-fuse/ for more information about using JBoss Fuse
 
 
 System requirements

--- a/rest/README.md
+++ b/rest/README.md
@@ -20,7 +20,7 @@ In studying this quick start you will learn:
 
 For more information see:
 
-* <https://access.redhat.com/site/documentation/JBoss_Fuse/> for more information about using JBoss Fuse
+* <https://access.redhat.com/site/documentation/red-hat-jboss-fuse/> for more information about using JBoss Fuse
 
 System requirements
 -------------------

--- a/secure-rest/README.md
+++ b/secure-rest/README.md
@@ -21,7 +21,7 @@ In studying this quick start you will learn:
 
 For more information see:
 
-* https://access.redhat.com/site/documentation/JBoss_Fuse/ for more information about using JBoss Fuse
+* https://access.redhat.com/site/documentation/red-hat-jboss-fuse/ for more information about using JBoss Fuse
 
 System requirements
 -------------------

--- a/secure-soap/README.md
+++ b/secure-soap/README.md
@@ -22,7 +22,7 @@ In studying this quick start you will learn:
 
 For more information see:
 
-* https://access.redhat.com/site/documentation/JBoss_Fuse/ for more information about using JBoss Fuse
+* https://access.redhat.com/site/documentation/red-hat-jboss-fuse/ for more information about using JBoss Fuse
 
 System requirements
 -------------------


### PR DESCRIPTION
Links for documentation in the README files pointing to the Customer Portal link were incorrect.
This PR is to correct them links to point to the correct location.
